### PR TITLE
🧹 [code health] Remove commented-out NVM_DIR export

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,6 @@ if [ ! -d "$HOME/.nvm" ]; then
 fi
 
 # Source nvm script to make nvm command available
-#export NVM_DIR="$HOME/.nvm"
 export NVM_DIR="/usr/local/share/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"


### PR DESCRIPTION
Removed a commented-out NVM_DIR export line in `install.sh` to improve code health and readability. Verified the change with `bash -n`.

---
*PR created automatically by Jules for task [14947183574635331821](https://jules.google.com/task/14947183574635331821) started by @josephrkramer*