### PR TITLE
Set default Git username and email

### DIFF
--- a/chromeos/set_git_config.sh
+++ b/chromeos/set_git_config.sh
@@ -11,7 +11,8 @@ validate_email() {
 
 # Get username
 while true; do
-  read -p "Enter your full name: " username
+  read -p "Enter your full name [Joseph Kramer]: " username
+  username="${username:-Joseph Kramer}"
   if [[ -n "$username" ]]; then # Check if username is not empty
     break
   else
@@ -22,7 +23,8 @@ done
 
 # Get email address with validation
 while true; do
-  read -p "Enter your Git email address: " email
+  read -p "Enter your Git email address [joseph.ryan.kramer@gmail.com]: " email
+  email="${email:-joseph.ryan.kramer@gmail.com}"
   if validate_email "$email"; then
     break
   else


### PR DESCRIPTION
This updates `chromeos/set_git_config.sh` to prompt with and fall back to "Joseph Kramer" and "joseph.ryan.kramer@gmail.com" as default username and email values respectively.

---
*PR created automatically by Jules for task [101644758939116925](https://jules.google.com/task/101644758939116925) started by @josephrkramer*