### PR TITLE
feat: add headless mode to setup script

### DIFF
--- a/chromeos/setup.sh
+++ b/chromeos/setup.sh
@@ -2,11 +2,17 @@
 set -euo pipefail
 
 HEADLESS=0
-
-for arg in "$@"; do
-  if [ "$arg" == "--headless" ]; then
-    HEADLESS=1
-  fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --headless)
+      HEADLESS=1
+      shift # past argument
+      ;;
+    *)
+      # unknown option
+      shift # past argument
+      ;;
+  esac
 done
 
 # install btop first so progress can be monitored for the rest of the setup

--- a/chromeos/setup.sh
+++ b/chromeos/setup.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+HEADLESS=0
+
+for arg in "$@"; do
+  if [ "$arg" == "--headless" ]; then
+    HEADLESS=1
+  fi
+done
+
 # install btop first so progress can be monitored for the rest of the setup
 ./install-btop.sh
 
@@ -12,7 +20,9 @@ set -euo pipefail
 gh auth login
 
 # install vscode
-./install-vscode.sh
+if [ "$HEADLESS" -eq 0 ]; then
+  ./install-vscode.sh
+fi
 
 # install nodejs
 ./install-node.sh
@@ -26,7 +36,9 @@ export NVM_DIR="$HOME/.config/nvm"
 ./install-gemini.sh
 
 # install antigravity
-./install-antigravity.sh
+if [ "$HEADLESS" -eq 0 ]; then
+  ./install-antigravity.sh
+fi
 
 # install chrome (required for antigravity agent browser)
 #./install-chrome.sh


### PR DESCRIPTION
Added a `--headless` argument to `chromeos/setup.sh` to allow bypassing GUI-dependent component installations (VS Code and Antigravity) during setup.

---
*PR created automatically by Jules for task [12814264739376073785](https://jules.google.com/task/12814264739376073785) started by @josephrkramer*