### PR TITLE
Add `install-docker.sh` to automate Docker installation on Debian

### DIFF
--- a/chromeos/install-docker.sh
+++ b/chromeos/install-docker.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+install_docker() {
+  echo "Starting Docker installation..."
+
+  # Add Docker's official GPG key:
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates curl
+  sudo install -m 0755 -d /etc/apt/keyrings
+  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+  sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+  # Add the repository to Apt sources:
+  # The environment may be Ubuntu masquerading as Debian or vice versa, so we check for ubuntu vs debian.
+  local OS_ID
+  OS_ID=$(. /etc/os-release && echo "$ID")
+  sudo tee /etc/apt/sources.list.d/docker.sources > /dev/null <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/${OS_ID}
+Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+Components: stable
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
+
+  sudo apt-get update
+
+  # Install Docker packages:
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+  # Add the current user to the docker group
+  sudo usermod -aG docker "$USER"
+
+  echo "Docker installation finished."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  install_docker
+fi

--- a/chromeos/install-docker.sh
+++ b/chromeos/install-docker.sh
@@ -36,6 +36,9 @@ EOF
   echo "You must log out and log back in for this change to take effect."
 
   echo "Docker installation finished."
+
+  echo
+  echo "Try the command 'docker run hello-world' to test the installation"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/chromeos/install-docker.sh
+++ b/chromeos/install-docker.sh
@@ -31,6 +31,10 @@ EOF
   # Add the current user to the docker group
   sudo usermod -aG docker "$USER"
 
+  echo
+  echo "User '$USER' has been added to the 'docker' group."
+  echo "You must log out and log back in for this change to take effect."
+
   echo "Docker installation finished."
 }
 


### PR DESCRIPTION
This PR introduces a new bash script, `chromeos/install-docker.sh`, which automates the installation of Docker on Debian and Debian-based systems (like Ubuntu) by following the official Docker installation steps. It also adds the current user to the `docker` group so that Docker commands can be run without `sudo`. The script uses `apt-get` with the `-y` flag for non-interactive execution and incorporates dynamic detection of the OS ID to ensure it fetches the correct repository for the underlying distribution.

Features included:
- Updates package indexes and installs dependencies (`ca-certificates`, `curl`).
- Adds the official Docker GPG key.
- Configures the correct Docker apt repository based on the OS.
- Installs Docker Engine, CLI, containerd, and Compose plugins.
- Adds the current user to the `docker` group.
- Wraps the installation logic in a function `install_docker` inside a conditional block checking `${BASH_SOURCE[0]}` to facilitate potential unit testing without executing side effects.

---
*PR created automatically by Jules for task [10626468902595950053](https://jules.google.com/task/10626468902595950053) started by @josephrkramer*