### PR TITLE
Add Termux script to install Ollama

### DIFF
--- a/termux/install-ollama.sh
+++ b/termux/install-ollama.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+install_ollama() {
+  pkg install -y ollama
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  install_ollama
+fi


### PR DESCRIPTION
This PR adds an installation script `termux/install-ollama.sh` to install Ollama on Termux environments natively. The script uses the `pkg` package manager since Ollama is available in the official Termux repositories and wraps the installation in a function that is executed following the conventions of the repository.

---
*PR created automatically by Jules for task [4040015733961965423](https://jules.google.com/task/4040015733961965423) started by @josephrkramer*