### PR TITLE
fix: add build dependencies for gemini cli install in termux

### DIFF
--- a/termux/install-gemini.sh
+++ b/termux/install-gemini.sh
@@ -8,6 +8,8 @@ install_gemini() {
 
   # Install Gemini CLI globally using npm
   if ! command -v gemini > /dev/null; then
+    echo "Installing build dependencies for native modules..."
+    pkg install -y python make clang
     echo "Installing @google/gemini-cli..."
     npm install -g @google/gemini-cli
     echo "Gemini CLI installed successfully."


### PR DESCRIPTION
Adds python, make, and clang as dependencies before installing `@google/gemini-cli` globally, since packages like `tree-sitter-bash` compile native modules via `node-gyp` during install. This resolves `npm error gyp ERR! find Python` errors on Termux.

---
*PR created automatically by Jules for task [125340984910530888](https://jules.google.com/task/125340984910530888) started by @josephrkramer*