### PR TITLE
fix(termux): Add android_ndk_path to node-gyp configs

### DIFF
--- a/termux/install-gemini.sh
+++ b/termux/install-gemini.sh
@@ -11,6 +11,7 @@ install_gemini() {
     echo "Installing build dependencies for native modules..."
     pkg install -y python make clang
     echo "Installing @google/gemini-cli..."
+    mkdir -p ~/.gyp && echo "{'variables':{'android_ndk_path':''}}" > ~/.gyp/include.gypi
     npm install -g @google/gemini-cli
     echo "Gemini CLI installed successfully."
   else

--- a/termux/install-gemini.sh
+++ b/termux/install-gemini.sh
@@ -11,7 +11,9 @@ install_gemini() {
     echo "Installing build dependencies for native modules..."
     pkg install -y python make clang
     echo "Installing @google/gemini-cli..."
-    mkdir -p ~/.gyp && echo "{'variables':{'android_ndk_path':''}}" > ~/.gyp/include.gypi
+    if [ ! -f ~/.gyp/include.gypi ]; then
+      mkdir -p ~/.gyp && echo "{'variables':{'android_ndk_path':''}}" > ~/.gyp/include.gypi
+    fi
     npm install -g @google/gemini-cli
     echo "Gemini CLI installed successfully."
   else


### PR DESCRIPTION
Fix `android_ndk_path` undefined variable issue in node-gyp on Termux during native module compilation.

---
*PR created automatically by Jules for task [4479167188423987858](https://jules.google.com/task/4479167188423987858) started by @josephrkramer*