### PR TITLE
🧪 Add testing for chromeos/set_git_config.sh

### DIFF
--- a/chromeos/set_git_config.sh
+++ b/chromeos/set_git_config.sh
@@ -9,40 +9,46 @@ validate_email() {
   fi
 }
 
-# Get username
-while true; do
-  read -p "Enter your full name [Joseph Kramer]: " username
-  username="${username:-Joseph Kramer}"
-  if [[ -n "$username" ]]; then # Check if username is not empty
-    break
-  else
-    echo "Username cannot be empty. Please try again."
-  fi
-done
+set_git_config() {
+  # Get username
+  while true; do
+    read -p "Enter your full name [Joseph Kramer]: " username
+    username="${username:-Joseph Kramer}"
+    if [[ -n "$username" ]]; then # Check if username is not empty
+      break
+    else
+      echo "Username cannot be empty. Please try again."
+    fi
+  done
 
 
-# Get email address with validation
-while true; do
-  read -p "Enter your Git email address [joseph.ryan.kramer@gmail.com]: " email
-  email="${email:-joseph.ryan.kramer@gmail.com}"
-  if validate_email "$email"; then
-    break
-  else
-    echo "Invalid email format. Please try again."
-  fi
-done
+  # Get email address with validation
+  while true; do
+    read -p "Enter your Git email address [joseph.ryan.kramer@gmail.com]: " email
+    email="${email:-joseph.ryan.kramer@gmail.com}"
+    if validate_email "$email"; then
+      break
+    else
+      echo "Invalid email format. Please try again."
+    fi
+  done
 
-# Set Git config
-git config --global user.name "$username"
-git config --global user.email "$email"
-git config --global push.autoSetupRemote true 2>/dev/null
+  # Set Git config
+  git config --global user.name "$username"
+  git config --global user.email "$email"
+  git config --global push.autoSetupRemote true 2>/dev/null
 
-# Confirmation message
-echo "Git username and email set successfully:"
-echo "Username: $username"
-echo "Email: $email"
+  # Confirmation message
+  echo "Git username and email set successfully:"
+  echo "Username: $username"
+  echo "Email: $email"
 
-# Optional: Display current config
-git config --list | grep user.
+  # Optional: Display current config
+  git config --list | grep user.
 
-echo "You're all set!"
+  echo "You're all set!"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set_git_config
+fi

--- a/chromeos/test_set_git_config.sh
+++ b/chromeos/test_set_git_config.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Source the script to test
+. "$(dirname "${BASH_SOURCE[0]}")/set_git_config.sh"
+
+# Test valid email
+if ! validate_email "test@example.com"; then
+  echo "test_set_git_config.sh: failed on valid email (test@example.com)"
+  exit 1
+fi
+
+# Test another valid email with a subdomain
+if ! validate_email "user.name+tag@sub.domain.co.uk"; then
+  echo "test_set_git_config.sh: failed on valid email (user.name+tag@sub.domain.co.uk)"
+  exit 1
+fi
+
+# Test invalid email (no domain)
+if validate_email "invalid-email"; then
+  echo "test_set_git_config.sh: failed on invalid email (invalid-email)"
+  exit 1
+fi
+
+# Test invalid email (no @ symbol)
+if validate_email "testexample.com"; then
+  echo "test_set_git_config.sh: failed on invalid email (testexample.com)"
+  exit 1
+fi
+
+# Test invalid email (missing TLD)
+if validate_email "test@example"; then
+  echo "test_set_git_config.sh: failed on invalid email (test@example)"
+  exit 1
+fi
+
+echo "test_set_git_config.sh passed"
+exit 0


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a test script `chromeos/test_set_git_config.sh` to test the email validation logic in `chromeos/set_git_config.sh`. To make it testable, the main interactive logic in `set_git_config.sh` was wrapped in a function that only executes when the script is run directly, not when sourced.

📊 **Coverage:** What scenarios are now tested
The `validate_email` function is now explicitly tested against:
*   Standard valid email (`test@example.com`)
*   Valid email with subdomains and tags (`user.name+tag@sub.domain.co.uk`)
*   Invalid email missing domain (`invalid-email`)
*   Invalid email missing `@` symbol (`testexample.com`)
*   Invalid email missing TLD (`test@example`)

✨ **Result:** The improvement in test coverage
The email validation logic is now protected by tests, ensuring future refactors won't inadvertently break the regex validation. The script is also much more robust against side-effects during testing.

---
*PR created automatically by Jules for task [911421412654342011](https://jules.google.com/task/911421412654342011) started by @josephrkramer*