### PR TITLE
🧪 Add test coverage for chromeos/install-tripo.sh

### DIFF
--- a/chromeos/install-tripo.sh
+++ b/chromeos/install-tripo.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 set -euo pipefail
 
-sudo apt update
-sudo apt install -y python3-pip python3-venv
+install_tripo() {
+  sudo apt update
+  sudo apt install -y python3-pip python3-venv
 
-cd ~
+  cd ~
 
-git clone https://github.com/VAST-AI-Research/TripoSR.git
-cd TripoSR
+  git clone https://github.com/VAST-AI-Research/TripoSR.git
+  cd TripoSR
 
-python3 -m venv .venv
-source .venv/bin/activate
+  python3 -m venv .venv
+  source .venv/bin/activate
 
-pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+  pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 
-pip install --upgrade setuptools
-pip install -r requirements.txt
+  pip install --upgrade setuptools
+  pip install -r requirements.txt
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  install_tripo
+fi

--- a/chromeos/test_install-tripo.sh
+++ b/chromeos/test_install-tripo.sh
@@ -61,7 +61,16 @@ cd "$MOCK_DIR"
 export HOME="$MOCK_DIR"
 
 # Run the function
-install_tripo
+output=$(install_tripo)
+
+# Verify that key commands were called. `set -e` will cause a failure if any are missing.
+echo "$output" | grep -q "Mock sudo: apt update"
+echo "$output" | grep -q "Mock sudo: apt install -y python3-pip python3-venv"
+echo "$output" | grep -q "Mock git: clone https://github.com/VAST-AI-Research/TripoSR.git"
+echo "$output" | grep -q "Mock python3 venv: -m venv .venv"
+echo "$output" | grep -q "Mock pip3: install torch torchvision --index-url https://download.pytorch.org/whl/cpu"
+echo "$output" | grep -q "Mock pip: install --upgrade setuptools"
+echo "$output" | grep -q "Mock pip: install -r requirements.txt"
 
 echo "test_install-tripo.sh passed"
 exit 0

--- a/chromeos/test_install-tripo.sh
+++ b/chromeos/test_install-tripo.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+# Set up a mock directory
+MOCK_DIR=$(mktemp -d)
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+# Create mocks for external commands
+cat << 'EOF' > "$MOCK_DIR/sudo"
+#!/bin/bash
+echo "Mock sudo: $@"
+EOF
+chmod +x "$MOCK_DIR/sudo"
+
+cat << 'EOF' > "$MOCK_DIR/apt"
+#!/bin/bash
+echo "Mock apt: $@"
+EOF
+chmod +x "$MOCK_DIR/apt"
+
+cat << 'EOF' > "$MOCK_DIR/git"
+#!/bin/bash
+echo "Mock git: $@"
+EOF
+chmod +x "$MOCK_DIR/git"
+
+cat << 'EOF' > "$MOCK_DIR/python3"
+#!/bin/bash
+if [[ "$1" == "-m" && "$2" == "venv" ]]; then
+  echo "Mock python3 venv: $@"
+  mkdir -p "$3/bin"
+  touch "$3/bin/activate"
+  chmod +x "$3/bin/activate"
+else
+  echo "Mock python3: $@"
+fi
+EOF
+chmod +x "$MOCK_DIR/python3"
+
+cat << 'EOF' > "$MOCK_DIR/pip3"
+#!/bin/bash
+echo "Mock pip3: $@"
+EOF
+chmod +x "$MOCK_DIR/pip3"
+
+cat << 'EOF' > "$MOCK_DIR/pip"
+#!/bin/bash
+echo "Mock pip: $@"
+EOF
+chmod +x "$MOCK_DIR/pip"
+
+# Override PATH to use mocks
+export PATH="$MOCK_DIR:$PATH"
+
+# Source the target script
+source chromeos/install-tripo.sh
+
+# Provide a mock TripoSR dir for 'cd TripoSR' to work
+mkdir -p "$MOCK_DIR/TripoSR"
+cd "$MOCK_DIR"
+export HOME="$MOCK_DIR"
+
+# Run the function
+install_tripo
+
+echo "test_install-tripo.sh passed"
+exit 0


### PR DESCRIPTION
🎯 **What:** The testing gap addressed. `chromeos/install-tripo.sh` was lacking a test script. The script was modified to wrap its execution in a testable function `install_tripo` and a new test script was added.
📊 **Coverage:** What scenarios are now tested. The test script covers the successful execution of the `install_tripo` function by setting up a temporary mocked environment (mocking `sudo`, `apt`, `git`, `python3`, `pip`, and `pip3`) and intercepting the calls to verify the script functions without side effects.
✨ **Result:** The improvement in test coverage. The testing coverage is improved by allowing the execution of the `install-tripo.sh` installation sequence to be verified locally without requiring root privileges or modifying system state.

---
*PR created automatically by Jules for task [223532407957390355](https://jules.google.com/task/223532407957390355) started by @josephrkramer*