### PR TITLE
🧪 Add test file for termux/install-ollama.sh

### DIFF
--- a/termux/test_install-ollama.sh
+++ b/termux/test_install-ollama.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+MOCK_DIR="$(mktemp -d)"
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+cat << 'EOF' > "$MOCK_DIR/pkg"
+#!/bin/bash
+echo "Mock pkg called with args: $*" >&2
+EOF
+chmod +x "$MOCK_DIR/pkg"
+
+export PATH="$MOCK_DIR:$PATH"
+
+. "$(dirname "${BASH_SOURCE[0]}")/install-ollama.sh"
+
+install_ollama
+
+echo "test_install-ollama.sh passed"
+exit 0

--- a/termux/test_install-ollama.sh
+++ b/termux/test_install-ollama.sh
@@ -14,7 +14,15 @@ export PATH="$MOCK_DIR:$PATH"
 
 . "$(dirname "${BASH_SOURCE[0]}")/install-ollama.sh"
 
-install_ollama
+OUTPUT="$(install_ollama 2>&1)"
+EXPECTED="Mock pkg called with args: install -y ollama"
+
+if [[ "$OUTPUT" != "$EXPECTED" ]]; then
+  echo "Test failed: Unexpected output from install_ollama." >&2
+  echo "Expected: '$EXPECTED'" >&2
+  echo "Actual:   '$OUTPUT'" >&2
+  exit 1
+fi
 
 echo "test_install-ollama.sh passed"
 exit 0


### PR DESCRIPTION
🎯 **What:** Created missing test file for termux/install-ollama.sh.
📊 **Coverage:** Successfully mocks the pkg command, sources the script, and executes the install_ollama function to ensure the script does not contain any errors.
✨ **Result:** Test coverage for termux/install-ollama.sh has been successfully increased to test execution.

---
*PR created automatically by Jules for task [15875514364701800221](https://jules.google.com/task/15875514364701800221) started by @josephrkramer*