### PR TITLE
🧪 [Add test coverage for chromeos/install-btop.sh]

### DIFF
--- a/chromeos/install-btop.sh
+++ b/chromeos/install-btop.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-sudo apt update
-sudo apt install -y btop
+install_btop() {
+  sudo apt update
+  sudo apt install -y btop
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  install_btop
+fi

--- a/chromeos/test_install-btop.sh
+++ b/chromeos/test_install-btop.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+# Set up mock environment
+MOCK_DIR=$(mktemp -d)
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+export PATH="$MOCK_DIR:$PATH"
+
+# Create mock for sudo
+cat << 'EOF' > "$MOCK_DIR/sudo"
+#!/bin/bash
+echo "MOCK SUDO: $@" >&2
+if [[ "${MOCK_SUDO_FAIL:-0}" == "1" ]]; then
+    exit 1
+fi
+exit 0
+EOF
+chmod +x "$MOCK_DIR/sudo"
+
+# Source the script
+. "$(dirname "${BASH_SOURCE[0]}")/install-btop.sh"
+
+echo "Running tests for chromeos/install-btop.sh..."
+
+# Test 1: Happy path
+echo "Test 1: Happy path"
+export MOCK_SUDO_FAIL=0
+if install_btop; then
+    echo "  Passed: install_btop succeeded as expected."
+else
+    echo "  Failed: install_btop should have succeeded."
+    exit 1
+fi
+
+# Test 2: Error path (sudo fails)
+echo "Test 2: Error path"
+export MOCK_SUDO_FAIL=1
+if ! install_btop; then
+    echo "  Passed: install_btop failed as expected."
+else
+    echo "  Failed: install_btop should have failed."
+    exit 1
+fi
+
+echo "All tests passed for chromeos/install-btop.sh"
+exit 0

--- a/chromeos/test_install-btop.sh
+++ b/chromeos/test_install-btop.sh
@@ -10,6 +10,7 @@ export PATH="$MOCK_DIR:$PATH"
 # Create mock for sudo
 cat << 'EOF' > "$MOCK_DIR/sudo"
 #!/bin/bash
+echo "$@" >> "$SUDO_CALLS_LOG"
 echo "MOCK SUDO: $@" >&2
 if [[ "${MOCK_SUDO_FAIL:-0}" == "1" ]]; then
     exit 1


### PR DESCRIPTION
🎯 **What:** Refactored `chromeos/install-btop.sh` to wrap its logic in a sourceable function, and added test coverage for it.
📊 **Coverage:** Tests the success path (`sudo apt install` completes) and the failure path (e.g., `sudo` fails).
✨ **Result:** Increased unit test coverage for the chromeos installation scripts and ensured that `install-btop.sh` adheres to the repository's convention for testable bash scripts.

---
*PR created automatically by Jules for task [2875983443276957176](https://jules.google.com/task/2875983443276957176) started by @josephrkramer*