### PR TITLE
🧪 [testing] add robust tests for chromeos/setup.sh

### DIFF
--- a/chromeos/setup.sh
+++ b/chromeos/setup.sh
@@ -1,50 +1,56 @@
 #!/bin/bash
 set -euo pipefail
 
-HEADLESS=0
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --headless)
-      HEADLESS=1
-      shift # past argument
-      ;;
-    *)
-      # unknown option
-      shift # past argument
-      ;;
-  esac
-done
+setup_chromeos() {
+  HEADLESS=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --headless)
+        HEADLESS=1
+        shift # past argument
+        ;;
+      *)
+        # unknown option
+        shift # past argument
+        ;;
+    esac
+  done
 
-# install btop first so progress can be monitored for the rest of the setup
-./install-btop.sh
+  # install btop first so progress can be monitored for the rest of the setup
+  ./install-btop.sh
 
-# setup local git
-./set_git_config.sh
+  # setup local git
+  ./set_git_config.sh
 
-# setup github
-./install-gh-cli.sh
-gh auth login
+  # setup github
+  ./install-gh-cli.sh
+  gh auth login
 
-# install vscode
-if [ "$HEADLESS" -eq 0 ]; then
-  ./install-vscode.sh
+  # install vscode
+  if [ "$HEADLESS" -eq 0 ]; then
+    ./install-vscode.sh
+  fi
+
+  # install nodejs
+  ./install-node.sh
+
+  # Source nvm script so node and npm are available for subsequent steps
+  export NVM_DIR="$HOME/.config/nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+
+  # install gemini cli
+  ./install-gemini.sh
+
+  # install antigravity
+  if [ "$HEADLESS" -eq 0 ]; then
+    ./install-antigravity.sh
+  fi
+
+  # install chrome (required for antigravity agent browser)
+  #./install-chrome.sh
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  setup_chromeos "$@"
 fi
-
-# install nodejs
-./install-node.sh
-
-# Source nvm script so node and npm are available for subsequent steps
-export NVM_DIR="$HOME/.config/nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-
-# install gemini cli
-./install-gemini.sh
-
-# install antigravity
-if [ "$HEADLESS" -eq 0 ]; then
-  ./install-antigravity.sh
-fi
-
-# install chrome (required for antigravity agent browser)
-#./install-chrome.sh

--- a/chromeos/test_setup.sh
+++ b/chromeos/test_setup.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create a temporary directory for mock executables
+MOCK_DIR=$(mktemp -d)
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+# Create a mock home directory to test NVM environment variables
+export HOME="$MOCK_DIR/home"
+mkdir -p "$HOME/.config/nvm"
+touch "$HOME/.config/nvm/nvm.sh"
+touch "$HOME/.config/nvm/bash_completion"
+
+# Create mock scripts for the dependencies called in setup_chromeos
+cat << 'EOF' > "$MOCK_DIR/install-btop.sh"
+#!/bin/bash
+echo "Mocked install-btop.sh"
+EOF
+chmod +x "$MOCK_DIR/install-btop.sh"
+
+cat << 'EOF' > "$MOCK_DIR/set_git_config.sh"
+#!/bin/bash
+echo "Mocked set_git_config.sh"
+EOF
+chmod +x "$MOCK_DIR/set_git_config.sh"
+
+cat << 'EOF' > "$MOCK_DIR/install-gh-cli.sh"
+#!/bin/bash
+echo "Mocked install-gh-cli.sh"
+EOF
+chmod +x "$MOCK_DIR/install-gh-cli.sh"
+
+cat << 'EOF' > "$MOCK_DIR/install-vscode.sh"
+#!/bin/bash
+echo "Mocked install-vscode.sh"
+EOF
+chmod +x "$MOCK_DIR/install-vscode.sh"
+
+cat << 'EOF' > "$MOCK_DIR/install-node.sh"
+#!/bin/bash
+echo "Mocked install-node.sh"
+EOF
+chmod +x "$MOCK_DIR/install-node.sh"
+
+cat << 'EOF' > "$MOCK_DIR/install-gemini.sh"
+#!/bin/bash
+echo "Mocked install-gemini.sh"
+EOF
+chmod +x "$MOCK_DIR/install-gemini.sh"
+
+cat << 'EOF' > "$MOCK_DIR/install-antigravity.sh"
+#!/bin/bash
+echo "Mocked install-antigravity.sh"
+EOF
+chmod +x "$MOCK_DIR/install-antigravity.sh"
+
+# Mock 'gh' command
+cat << 'EOF' > "$MOCK_DIR/gh"
+#!/bin/bash
+echo "Mocked gh $@"
+EOF
+chmod +x "$MOCK_DIR/gh"
+
+# Override PATH to prioritize mocks
+export PATH="$MOCK_DIR:$PATH"
+
+# Determine the absolute directory of the script before pushing directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Go to the mock directory so relative paths in the script resolve to our mocks
+pushd "$MOCK_DIR" > /dev/null
+
+# Source the setup script using absolute path resolution
+# The script is expected to be alongside this test file.
+. "$SCRIPT_DIR/setup.sh"
+
+echo "Testing headless=0 (default)..."
+setup_chromeos
+
+echo "Testing --headless..."
+setup_chromeos --headless
+
+popd > /dev/null
+
+echo "test_setup.sh passed"
+exit 0

--- a/chromeos/test_setup.sh
+++ b/chromeos/test_setup.sh
@@ -11,48 +11,24 @@ mkdir -p "$HOME/.config/nvm"
 touch "$HOME/.config/nvm/nvm.sh"
 touch "$HOME/.config/nvm/bash_completion"
 
+# Helper function to create mock scripts
+create_mock() {
+  local script_name="$1"
+  cat << EOF > "$MOCK_DIR/$script_name"
+#!/bin/bash
+echo "Mocked $script_name"
+EOF
+  chmod +x "$MOCK_DIR/$script_name"
+}
+
 # Create mock scripts for the dependencies called in setup_chromeos
-cat << 'EOF' > "$MOCK_DIR/install-btop.sh"
-#!/bin/bash
-echo "Mocked install-btop.sh"
-EOF
-chmod +x "$MOCK_DIR/install-btop.sh"
-
-cat << 'EOF' > "$MOCK_DIR/set_git_config.sh"
-#!/bin/bash
-echo "Mocked set_git_config.sh"
-EOF
-chmod +x "$MOCK_DIR/set_git_config.sh"
-
-cat << 'EOF' > "$MOCK_DIR/install-gh-cli.sh"
-#!/bin/bash
-echo "Mocked install-gh-cli.sh"
-EOF
-chmod +x "$MOCK_DIR/install-gh-cli.sh"
-
-cat << 'EOF' > "$MOCK_DIR/install-vscode.sh"
-#!/bin/bash
-echo "Mocked install-vscode.sh"
-EOF
-chmod +x "$MOCK_DIR/install-vscode.sh"
-
-cat << 'EOF' > "$MOCK_DIR/install-node.sh"
-#!/bin/bash
-echo "Mocked install-node.sh"
-EOF
-chmod +x "$MOCK_DIR/install-node.sh"
-
-cat << 'EOF' > "$MOCK_DIR/install-gemini.sh"
-#!/bin/bash
-echo "Mocked install-gemini.sh"
-EOF
-chmod +x "$MOCK_DIR/install-gemini.sh"
-
-cat << 'EOF' > "$MOCK_DIR/install-antigravity.sh"
-#!/bin/bash
-echo "Mocked install-antigravity.sh"
-EOF
-chmod +x "$MOCK_DIR/install-antigravity.sh"
+create_mock "install-btop.sh"
+create_mock "set_git_config.sh"
+create_mock "install-gh-cli.sh"
+create_mock "install-vscode.sh"
+create_mock "install-node.sh"
+create_mock "install-gemini.sh"
+create_mock "install-antigravity.sh"
 
 # Mock 'gh' command
 cat << 'EOF' > "$MOCK_DIR/gh"

--- a/chromeos/test_setup.sh
+++ b/chromeos/test_setup.sh
@@ -51,10 +51,20 @@ pushd "$MOCK_DIR" > /dev/null
 . "$SCRIPT_DIR/setup.sh"
 
 echo "Testing headless=0 (default)..."
-setup_chromeos
+output=$(setup_chromeos)
+echo "$output" | grep -q "Mocked install-vscode.sh"
+echo "$output" | grep -q "Mocked install-antigravity.sh"
 
 echo "Testing --headless..."
-setup_chromeos --headless
+output=$(setup_chromeos --headless)
+if echo "$output" | grep -q "Mocked install-vscode.sh"; then
+  echo "FAIL: install-vscode.sh was called in headless mode" >&2
+  exit 1
+fi
+if echo "$output" | grep -q "Mocked install-antigravity.sh"; then
+  echo "FAIL: install-antigravity.sh was called in headless mode" >&2
+  exit 1
+fi
 
 popd > /dev/null
 


### PR DESCRIPTION
🎯 **What:** The `chromeos/setup.sh` script lacked test coverage and wasn't wrapped in a sourceable function.
📊 **Coverage:** Created `chromeos/test_setup.sh` to test both the default headless=0 mode and `--headless` explicitly, mocking all dependency scripts and `gh` to verify isolated script execution.
✨ **Result:** Improved test coverage, safety, and reliability for the ChromeOS setup configuration without side effects.

---
*PR created automatically by Jules for task [17755315797867351525](https://jules.google.com/task/17755315797867351525) started by @josephrkramer*