### PR TITLE
✨ [feat] add opencode installation for chromeos

### DIFF
--- a/chromeos/install-opencode.sh
+++ b/chromeos/install-opencode.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+install_opencode() {
+  echo "Starting OpenCode install script..."
+
+  # --- Install OpenCode CLI ---
+
+  # Install OpenCode CLI globally using npm
+  if ! command -v opencode > /dev/null; then
+    echo "Installing opencode-ai..."
+    npm install -g opencode-ai
+    echo "OpenCode CLI installed successfully."
+  else
+    echo "OpenCode CLI is already installed."
+  fi
+
+  echo "OpenCode CLI install script finished."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  install_opencode
+fi

--- a/chromeos/setup.sh
+++ b/chromeos/setup.sh
@@ -42,6 +42,9 @@ setup_chromeos() {
   # install gemini cli
   ./install-gemini.sh
 
+  # install opencode
+  ./install-opencode.sh
+
   # install antigravity
   if [ "$HEADLESS" -eq 0 ]; then
     ./install-antigravity.sh

--- a/chromeos/test_install-opencode.sh
+++ b/chromeos/test_install-opencode.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+# Create a mock environment
+MOCK_DIR=$(mktemp -d)
+export PATH="$MOCK_DIR:$PATH"
+export NVM_DIR="$MOCK_DIR/.nvm"
+mkdir -p "$NVM_DIR"
+
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+# Mock npm to prevent actual installation during testing
+cat << 'EOF' > "$MOCK_DIR/npm"
+#!/bin/bash
+echo "Mock npm called with args: $@"
+EOF
+chmod +x "$MOCK_DIR/npm"
+
+# Mock command to simulate opencode not being installed
+# We override the builtin command so we can fake the check
+# However, `command -v opencode` is used in the script.
+# `command` is a shell builtin. We can create a function to intercept it.
+# Actually, it's better to just ensure opencode is not in the mock path.
+# We don't need to mock `command`. The script will use `command -v opencode`.
+# Since `opencode` is not in the mock path, it will fail, which is what we want for the install path test.
+
+
+source chromeos/install-opencode.sh
+
+# Run the function
+if ! install_opencode; then
+    echo "test_install-opencode.sh failed"
+    exit 1
+fi
+
+echo "test_install-opencode.sh passed"
+exit 0

--- a/chromeos/test_install-opencode.sh
+++ b/chromeos/test_install-opencode.sh
@@ -24,7 +24,8 @@ chmod +x "$MOCK_DIR/npm"
 # Since `opencode` is not in the mock path, it will fail, which is what we want for the install path test.
 
 
-source chromeos/install-opencode.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/install-opencode.sh"
 
 # Run the function
 if ! install_opencode; then

--- a/chromeos/test_setup.sh
+++ b/chromeos/test_setup.sh
@@ -28,6 +28,7 @@ create_mock "install-gh-cli.sh"
 create_mock "install-vscode.sh"
 create_mock "install-node.sh"
 create_mock "install-gemini.sh"
+create_mock "install-opencode.sh"
 create_mock "install-antigravity.sh"
 
 # Mock 'gh' command


### PR DESCRIPTION
🎯 What
Adds a script `install-opencode.sh` to install the `opencode` CLI tool via `npm install -g opencode-ai` for ChromeOS, updates `setup.sh` to execute it, and adds corresponding tests.

💡 Why
To automate the installation of OpenCode as part of the ChromeOS dotfiles setup routine, ensuring the tool is available for use.

✅ Verification
Ran the unit tests in `chromeos/test_install-opencode.sh` successfully, and verified `chromeos/test_setup.sh` passes after mocking the new script.

✨ Result
`setup.sh` for ChromeOS now automatically installs `opencode`.

---
*PR created automatically by Jules for task [9289793854435260254](https://jules.google.com/task/9289793854435260254) started by @josephrkramer*