### PR TITLE
🧪 Improve testing and error handling for pdfsplit.sh

### DIFF
--- a/chromeos/pdfsplit.sh
+++ b/chromeos/pdfsplit.sh
@@ -50,7 +50,7 @@ split_pdf() {
             END=$(( i * PAGES_PER_PIECE ))
         fi
 
-        OUTPUT_NAME="${FILE%.pdf}_part${i}.pdf"
+        OUTPUT_NAME="${FILE%.*}_part${i}.pdf"
 
         echo "Creating $OUTPUT_NAME (Pages $START-$END)..."
         qpdf --empty --pages "$FILE" "$START-$END" -- "$OUTPUT_NAME"

--- a/chromeos/pdfsplit.sh
+++ b/chromeos/pdfsplit.sh
@@ -28,7 +28,7 @@ split_pdf() {
     TOTAL_PAGES=$(qpdf --show-npages "$FILE")
 
     # 4. Calculate pages per piece (integer division)
-    local PAGES_PER_PIECE=$((TOTAL_PAGES / 10#$PIECES))
+    local PAGES_PER_PIECE=$((TOTAL_PAGES / PIECES))
 
     if [ "$PAGES_PER_PIECE" -eq 0 ]; then
         echo "Error: Number of pieces exceeds number of pages."
@@ -39,8 +39,8 @@ split_pdf() {
     echo "Splitting into $PIECES pieces (approx $PAGES_PER_PIECE pages each)..."
 
     # 5. Loop and extract
-    local i START END OUTPUT_NAME
-    for i in $(seq 1 "$PIECES"); do
+    local START END OUTPUT_NAME i
+    for ((i=1; i<=PIECES; i++)); do
         START=$(( (i - 1) * PAGES_PER_PIECE + 1 ))
 
         # If it's the last piece, capture all remaining pages
@@ -50,7 +50,7 @@ split_pdf() {
             END=$(( i * PAGES_PER_PIECE ))
         fi
 
-        OUTPUT_NAME="${FILE%.*}_part${i}.pdf"
+        OUTPUT_NAME="${FILE%.[Pp][Dd][Ff]}_part${i}.pdf"
 
         echo "Creating $OUTPUT_NAME (Pages $START-$END)..."
         qpdf --empty --pages "$FILE" "$START-$END" -- "$OUTPUT_NAME"

--- a/chromeos/pdfsplit.sh
+++ b/chromeos/pdfsplit.sh
@@ -28,7 +28,7 @@ split_pdf() {
     TOTAL_PAGES=$(qpdf --show-npages "$FILE")
 
     # 4. Calculate pages per piece (integer division)
-    local PAGES_PER_PIECE=$((TOTAL_PAGES / PIECES))
+    local PAGES_PER_PIECE=$((TOTAL_PAGES / 10#$PIECES))
 
     if [ "$PAGES_PER_PIECE" -eq 0 ]; then
         echo "Error: Number of pieces exceeds number of pages."

--- a/chromeos/pdfsplit.sh
+++ b/chromeos/pdfsplit.sh
@@ -2,55 +2,63 @@
 set -euo pipefail
 
 
-# 1. Check if qpdf is installed
-if ! command -v qpdf &> /dev/null; then
-    echo "Error: qpdf is not installed. Install it with: sudo apt install qpdf"
-    exit 1
-fi
-
-# 2. Check for required input
-FILE=$1
-PIECES=${2:-2} # Defaults to 2 if second argument is missing
-
-if [[ -z "$FILE" || ! -f "$FILE" ]]; then
-    echo "Usage: ./pdfsplit.sh <filename.pdf> [number_of_pieces]"
-    exit 1
-fi
-
-if ! [[ "$PIECES" =~ ^[0-9]+$ ]] || [ "$PIECES" -le 0 ]; then
-    echo "Error: Number of pieces must be a positive integer."
-    exit 1
-fi
-
-# 3. Get total page count
-TOTAL_PAGES=$(qpdf --show-npages "$FILE")
-
-# 4. Calculate pages per piece (integer division)
-PAGES_PER_PIECE=$((TOTAL_PAGES / PIECES))
-
-if [ "$PAGES_PER_PIECE" -eq 0 ]; then
-    echo "Error: Number of pieces exceeds number of pages."
-    exit 1
-fi
-
-echo "Total pages: $TOTAL_PAGES"
-echo "Splitting into $PIECES pieces (approx $PAGES_PER_PIECE pages each)..."
-
-# 5. Loop and extract
-for i in $(seq 1 "$PIECES"); do
-    START=$(( (i - 1) * PAGES_PER_PIECE + 1 ))
-    
-    # If it's the last piece, capture all remaining pages
-    if [ "$i" -eq "$PIECES" ]; then
-        END=$TOTAL_PAGES
-    else
-        END=$(( i * PAGES_PER_PIECE ))
+split_pdf() {
+    # 1. Check if qpdf is installed
+    if ! command -v qpdf &> /dev/null; then
+        echo "Error: qpdf is not installed. Install it with: sudo apt install qpdf"
+        return 1
     fi
-    
-    OUTPUT_NAME="${FILE%.pdf}_part${i}.pdf"
-    
-    echo "Creating $OUTPUT_NAME (Pages $START-$END)..."
-    qpdf --empty --pages "$FILE" "$START-$END" -- "$OUTPUT_NAME"
-done
 
-echo "Successfully split '$FILE' into $PIECES parts."
+    # 2. Check for required input
+    local FILE="${1:-}"
+    local PIECES="${2:-2}" # Defaults to 2 if second argument is missing
+
+    if [[ -z "$FILE" || ! -f "$FILE" ]]; then
+        echo "Usage: ./pdfsplit.sh <filename.pdf> [number_of_pieces]"
+        return 1
+    fi
+
+    if ! [[ "$PIECES" =~ ^[0-9]+$ ]] || [ "$PIECES" -le 0 ]; then
+        echo "Error: Number of pieces must be a positive integer."
+        return 1
+    fi
+
+    # 3. Get total page count
+    local TOTAL_PAGES
+    TOTAL_PAGES=$(qpdf --show-npages "$FILE")
+
+    # 4. Calculate pages per piece (integer division)
+    local PAGES_PER_PIECE=$((TOTAL_PAGES / PIECES))
+
+    if [ "$PAGES_PER_PIECE" -eq 0 ]; then
+        echo "Error: Number of pieces exceeds number of pages."
+        return 1
+    fi
+
+    echo "Total pages: $TOTAL_PAGES"
+    echo "Splitting into $PIECES pieces (approx $PAGES_PER_PIECE pages each)..."
+
+    # 5. Loop and extract
+    local i START END OUTPUT_NAME
+    for i in $(seq 1 "$PIECES"); do
+        START=$(( (i - 1) * PAGES_PER_PIECE + 1 ))
+
+        # If it's the last piece, capture all remaining pages
+        if [ "$i" -eq "$PIECES" ]; then
+            END=$TOTAL_PAGES
+        else
+            END=$(( i * PAGES_PER_PIECE ))
+        fi
+
+        OUTPUT_NAME="${FILE%.pdf}_part${i}.pdf"
+
+        echo "Creating $OUTPUT_NAME (Pages $START-$END)..."
+        qpdf --empty --pages "$FILE" "$START-$END" -- "$OUTPUT_NAME"
+    done
+
+    echo "Successfully split '$FILE' into $PIECES parts."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    split_pdf "$@"
+fi

--- a/chromeos/test_pdfsplit.sh
+++ b/chromeos/test_pdfsplit.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create a temporary directory for mock executables
+MOCK_DIR=$(mktemp -d)
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+# Create a mock for qpdf
+cat << 'EOF' > "$MOCK_DIR/qpdf"
+#!/bin/bash
+if [[ "$1" == "--show-npages" ]]; then
+    echo "10"
+    exit 0
+fi
+echo "Mocked qpdf $@"
+EOF
+chmod +x "$MOCK_DIR/qpdf"
+
+# Override PATH to prioritize mocks
+export PATH="$MOCK_DIR:$PATH"
+
+# Determine the absolute directory of the script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source the target script
+. "$SCRIPT_DIR/pdfsplit.sh"
+
+echo "Running tests for pdfsplit.sh..."
+
+echo "Test 1: No arguments should fail and print usage"
+OUTPUT=$(split_pdf 2>&1 || true)
+if ! echo "$OUTPUT" | grep -q "Usage: ./pdfsplit.sh <filename.pdf> \[number_of_pieces\]"; then
+    echo "FAIL: Expected usage error for no arguments" >&2
+    echo "Got: $OUTPUT" >&2
+    exit 1
+fi
+
+echo "Test 2: Non-existent file should fail and print usage"
+OUTPUT=$(split_pdf "nonexistent_file.pdf" 2>&1 || true)
+if ! echo "$OUTPUT" | grep -q "Usage: ./pdfsplit.sh <filename.pdf> \[number_of_pieces\]"; then
+    echo "FAIL: Expected usage error for non-existent file" >&2
+    echo "Got: $OUTPUT" >&2
+    exit 1
+fi
+
+echo "Test 3: Valid file but invalid pieces should fail"
+touch "$MOCK_DIR/dummy.pdf"
+OUTPUT=$(split_pdf "$MOCK_DIR/dummy.pdf" "invalid" 2>&1 || true)
+if ! echo "$OUTPUT" | grep -q "Error: Number of pieces must be a positive integer."; then
+    echo "FAIL: Expected positive integer error for invalid pieces" >&2
+    echo "Got: $OUTPUT" >&2
+    exit 1
+fi
+
+echo "Test 4: Pieces > Total Pages should fail"
+# Mock qpdf will return 10 pages. Try to split into 11 pieces.
+OUTPUT=$(split_pdf "$MOCK_DIR/dummy.pdf" 11 2>&1 || true)
+if ! echo "$OUTPUT" | grep -q "Error: Number of pieces exceeds number of pages."; then
+    echo "FAIL: Expected error for pieces > pages" >&2
+    echo "Got: $OUTPUT" >&2
+    exit 1
+fi
+
+echo "Test 5: Valid file and valid pieces (happy path)"
+OUTPUT=$(split_pdf "$MOCK_DIR/dummy.pdf" 2 2>&1 || true)
+if ! echo "$OUTPUT" | grep -q "Successfully split '$MOCK_DIR/dummy.pdf' into 2 parts."; then
+    echo "FAIL: Expected success message" >&2
+    echo "Got: $OUTPUT" >&2
+    exit 1
+fi
+if ! echo "$OUTPUT" | grep -q "Mocked qpdf --empty --pages $MOCK_DIR/dummy.pdf 1-5 -- $MOCK_DIR/dummy_part1.pdf"; then
+    echo "FAIL: Expected qpdf call for part 1 not found" >&2
+    echo "Got: $OUTPUT" >&2
+    exit 1
+fi
+if ! echo "$OUTPUT" | grep -q "Mocked qpdf --empty --pages $MOCK_DIR/dummy.pdf 6-10 -- $MOCK_DIR/dummy_part2.pdf"; then
+    echo "FAIL: Expected qpdf call for part 2 not found" >&2
+    echo "Got: $OUTPUT" >&2
+    exit 1
+fi
+
+echo "All tests passed for pdfsplit.sh!"
+exit 0


### PR DESCRIPTION
🎯 **What:** The `chromeos/pdfsplit.sh` script previously crashed on an unbound variable error under `set -u` when no arguments were provided, skipping intended usage errors. Also, it lacked a test suite.
📊 **Coverage:** Added a full suite (`chromeos/test_pdfsplit.sh`) that verifies behavior when no arguments are provided, when a file is missing, when an invalid piece count is given, when requested pieces exceed total pages, and a standard happy-path test.
✨ **Result:** Improved codebase reliability by introducing robust tests and properly handling missing parameters, which prevents ungraceful crashes in favor of helpful usage prompts.

---
*PR created automatically by Jules for task [2525501499851657958](https://jules.google.com/task/2525501499851657958) started by @josephrkramer*