### PR TITLE
🧹 Extract `validate_email` function to shared utility

### DIFF
--- a/chromeos/set_git_config.sh
+++ b/chromeos/set_git_config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/../common/git_utils.sh"
+. "$(dirname "${BASH_SOURCE[0]}")"/../common/git_utils.sh || { echo "Error: Failed to load common/git_utils.sh" >&2; exit 1; }
 
 set_git_config() {
   # Get username

--- a/chromeos/set_git_config.sh
+++ b/chromeos/set_git_config.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 
-# Function to validate email address format (basic check)
-validate_email() {
-  if [[ "$1" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
-    return 0  # Valid
-  else
-    return 1  # Invalid
-  fi
-}
+. "$(dirname "${BASH_SOURCE[0]}")/../common/git_utils.sh"
 
 set_git_config() {
   # Get username

--- a/common/git_utils.sh
+++ b/common/git_utils.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Function to validate email address format (basic check)
+validate_email() {
+  if [[ "$1" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
+    return 0  # Valid
+  else
+    return 1  # Invalid
+  fi
+}

--- a/common/git_utils.sh
+++ b/common/git_utils.sh
@@ -2,9 +2,5 @@
 
 # Function to validate email address format (basic check)
 validate_email() {
-  if [[ "$1" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
-    return 0  # Valid
-  else
-    return 1  # Invalid
-  fi
+  [[ "$1" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]
 }

--- a/termux/set_git_config.sh
+++ b/termux/set_git_config.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 
-# Function to validate email address format (basic check)
-validate_email() {
-  if [[ "$1" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
-    return 0  # Valid
-  else
-    return 1  # Invalid
-  fi
-}
+. "$(dirname "${BASH_SOURCE[0]}")/../common/git_utils.sh"
 
 set_git_config() {
     # Get username

--- a/termux/set_git_config.sh
+++ b/termux/set_git_config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/../common/git_utils.sh"
+. "$(dirname "${BASH_SOURCE[0]}")"/../common/git_utils.sh || { echo "Error: Failed to load common/git_utils.sh" >&2; exit 1; }
 
 set_git_config() {
     # Get username


### PR DESCRIPTION
🎯 **What:** Extracted the duplicated `validate_email` function from `chromeos/set_git_config.sh` and `termux/set_git_config.sh` into a new central shared utility script `common/git_utils.sh`. Updated both scripts to source the shared utility instead of duplicating the logic.
💡 **Why:** This improves maintainability and adheres to DRY (Don't Repeat Yourself) principles. If the email validation logic ever needs to be updated (e.g., to support a wider range of TLDs or more complex regex rules), it only needs to be updated in one place.
✅ **Verification:** Verified by ensuring the bash syntax is correct across all three files using `bash -n`, and by running the existing test suites (`chromeos/test_set_git_config.sh` and `termux/test_set_git_config.sh`), which all passed perfectly. Also ran the full test suite which passed successfully.
✨ **Result:** Reduced code duplication and created a clean shared location (`common/git_utils.sh`) for Git-related shell functions.

---
*PR created automatically by Jules for task [1539932613315932036](https://jules.google.com/task/1539932613315932036) started by @josephrkramer*