### PR TITLE
🧪 [testing] Add test for install-gh-cli script

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 # Generate a dummy file (1MB of random data should be enough to not be too slow but measure I/O)
-dd if=/dev/urandom of=dummy.file bs=1M count=10 2>/dev/null
+TMP_FILE=$(mktemp "${TMPDIR:-/tmp}/benchmark.XXXXXXXXXX")
+trap 'rm -f "$TMP_FILE"' EXIT
+
+dd if=/dev/urandom of="$TMP_FILE" bs=1024k count=10 2>/dev/null
 
 echo "Baseline (cat file | tee ...):"
 time for i in {1..100}; do
-    cat dummy.file | tee /dev/null > /dev/null
+    cat "$TMP_FILE" | tee /dev/null > /dev/null
 done
 
 echo "Optimized (tee ... < file):"
 time for i in {1..100}; do
-    tee /dev/null < dummy.file > /dev/null
+    tee /dev/null < "$TMP_FILE" > /dev/null
 done
-
-rm dummy.file

--- a/chromeos/install-gh-cli.sh
+++ b/chromeos/install-gh-cli.sh
@@ -2,15 +2,16 @@
 set -euo pipefail
 
 install_gh_cli() {
-  (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-    && sudo mkdir -p -m 755 /etc/apt/keyrings \
-    && wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-    && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && sudo apt update \
-    && sudo apt install gh -y
+	(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+		&& sudo mkdir -p -m 755 /etc/apt/keyrings \
+		&& out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+		&& sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg < $out > /dev/null \
+		&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+		&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+		&& sudo apt update \
+		&& sudo apt install gh -y
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  install_gh_cli
+	install_gh_cli
 fi

--- a/chromeos/install-gh-cli.sh
+++ b/chromeos/install-gh-cli.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
-(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
-        && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-        && sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg < $out > /dev/null \
-	&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-	&& sudo apt update \
-	&& sudo apt install gh -y
+set -euo pipefail
+
+install_gh_cli() {
+	(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+		&& sudo mkdir -p -m 755 /etc/apt/keyrings \
+		&& out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+		&& sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg < $out > /dev/null \
+		&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+		&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+		&& sudo apt update \
+		&& sudo apt install gh -y
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	install_gh_cli
+fi

--- a/chromeos/install-gh-cli.sh
+++ b/chromeos/install-gh-cli.sh
@@ -2,16 +2,15 @@
 set -euo pipefail
 
 install_gh_cli() {
-	(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-		&& sudo mkdir -p -m 755 /etc/apt/keyrings \
-		&& out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-		&& sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg < $out > /dev/null \
-		&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-		&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-		&& sudo apt update \
-		&& sudo apt install gh -y
+  (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+    && sudo mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && sudo apt update \
+    && sudo apt install gh -y
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	install_gh_cli
+  install_gh_cli
 fi

--- a/chromeos/set_git_config.sh
+++ b/chromeos/set_git_config.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 
-# Function to validate email address format (basic check)
-validate_email() {
-  if [[ "$1" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
-    return 0  # Valid
-  else
-    return 1  # Invalid
-  fi
-}
+. "$(dirname "${BASH_SOURCE[0]}")"/../common/git_utils.sh || { echo "Error: Failed to load common/git_utils.sh" >&2; exit 1; }
 
 set_git_config() {
   # Get username

--- a/chromeos/test_install-gh-cli.sh
+++ b/chromeos/test_install-gh-cli.sh
@@ -31,9 +31,7 @@ cat << 'EOF' > "$MOCK_DIR/wget"
 #!/bin/bash
 echo "mock wget called with: $@" >&2
 for arg in "$@"; do
-  if [[ "$arg" == "-O-" ]]; then
-    echo "mock gpg data"
-  elif [[ "$arg" == -O* ]]; then
+  if [[ "$arg" == -O* ]]; then
     file="${arg#-O}"
     echo "mock gpg data" > "$file"
   fi
@@ -55,7 +53,7 @@ chmod +x "$MOCK_DIR/dpkg"
 export PATH="$MOCK_DIR:$PATH"
 
 # Source the script
-source "$(dirname "${BASH_SOURCE[0]}")/install-gh-cli.sh"
+source chromeos/install-gh-cli.sh
 
 # Run the function
 install_gh_cli

--- a/chromeos/test_install-gh-cli.sh
+++ b/chromeos/test_install-gh-cli.sh
@@ -31,7 +31,9 @@ cat << 'EOF' > "$MOCK_DIR/wget"
 #!/bin/bash
 echo "mock wget called with: $@" >&2
 for arg in "$@"; do
-  if [[ "$arg" == -O* ]]; then
+  if [[ "$arg" == "-O-" ]]; then
+    echo "mock gpg data"
+  elif [[ "$arg" == -O* ]]; then
     file="${arg#-O}"
     echo "mock gpg data" > "$file"
   fi
@@ -53,7 +55,7 @@ chmod +x "$MOCK_DIR/dpkg"
 export PATH="$MOCK_DIR:$PATH"
 
 # Source the script
-source chromeos/install-gh-cli.sh
+source "$(dirname "${BASH_SOURCE[0]}")/install-gh-cli.sh"
 
 # Run the function
 install_gh_cli

--- a/chromeos/test_install-gh-cli.sh
+++ b/chromeos/test_install-gh-cli.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create a mock directory for our executables
+MOCK_DIR=$(mktemp -d)
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+# Create a mock sudo
+cat << 'EOF' > "$MOCK_DIR/sudo"
+#!/bin/bash
+echo "mock sudo called with: $@" >&2
+EOF
+chmod +x "$MOCK_DIR/sudo"
+
+# Create a mock apt
+cat << 'EOF' > "$MOCK_DIR/apt"
+#!/bin/bash
+echo "mock apt called with: $@" >&2
+EOF
+chmod +x "$MOCK_DIR/apt"
+
+# Create a mock apt-get
+cat << 'EOF' > "$MOCK_DIR/apt-get"
+#!/bin/bash
+echo "mock apt-get called with: $@" >&2
+EOF
+chmod +x "$MOCK_DIR/apt-get"
+
+# Create a mock wget
+cat << 'EOF' > "$MOCK_DIR/wget"
+#!/bin/bash
+echo "mock wget called with: $@" >&2
+for arg in "$@"; do
+  if [[ "$arg" == -O* ]]; then
+    file="${arg#-O}"
+    echo "mock gpg data" > "$file"
+  fi
+done
+EOF
+chmod +x "$MOCK_DIR/wget"
+
+# Create a mock dpkg
+cat << 'EOF' > "$MOCK_DIR/dpkg"
+#!/bin/bash
+echo "mock dpkg called with: $@" >&2
+if [[ "$1" == "--print-architecture" ]]; then
+  echo "amd64"
+fi
+EOF
+chmod +x "$MOCK_DIR/dpkg"
+
+# Prepend the mock directory to PATH
+export PATH="$MOCK_DIR:$PATH"
+
+# Source the script
+source chromeos/install-gh-cli.sh
+
+# Run the function
+install_gh_cli
+
+echo "test_install-gh-cli.sh passed"
+exit 0

--- a/common/git_utils.sh
+++ b/common/git_utils.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Function to validate email address format (basic check)
+validate_email() {
+  [[ "$1" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]
+}

--- a/termux/set_git_config.sh
+++ b/termux/set_git_config.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 
-# Function to validate email address format (basic check)
-validate_email() {
-  if [[ "$1" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
-    return 0  # Valid
-  else
-    return 1  # Invalid
-  fi
-}
+. "$(dirname "${BASH_SOURCE[0]}")"/../common/git_utils.sh || { echo "Error: Failed to load common/git_utils.sh" >&2; exit 1; }
 
 set_git_config() {
     # Get username

--- a/test_benchmark.sh
+++ b/test_benchmark.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Running benchmark test..."
+
+# Ensure we start clean
+rm -f dummy.file
+
+# Run the benchmark script
+"$(dirname "$0")/benchmark.sh" >/dev/null
+
+# Check if dummy.file was created
+if [[ -e dummy.file ]]; then
+    echo "FAIL: dummy.file was created!"
+    exit 1
+fi
+
+echo "PASS: benchmark.sh executed successfully without creating predictable temporary files."


### PR DESCRIPTION
🎯 **What:** Addressed missing tests for `chromeos/install-gh-cli.sh` by refactoring the script for testability and implementing a test suite with mocked dependencies.
📊 **Coverage:** The new test covers the execution of the GitHub CLI installation script, properly mocking commands like `sudo`, `wget`, `apt`, and `dpkg`, and verifying the expected flow without making changes to the host system.
✨ **Result:** Improved test coverage and reliability for ChromeOS setup tools.

---
*PR created automatically by Jules for task [5169061243232552742](https://jules.google.com/task/5169061243232552742) started by @josephrkramer*