### PR TITLE
🧹 Add starting progress echos to install scripts

### DIFF
--- a/chromeos/install-antigravity.sh
+++ b/chromeos/install-antigravity.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_antigravity() {
+  echo "Starting install-antigravity.sh..."
   sudo mkdir -p /etc/apt/keyrings
   curl -fsSL https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg | \
     sudo gpg --dearmor -o /etc/apt/keyrings/antigravity-repo-key.gpg

--- a/chromeos/install-btop.sh
+++ b/chromeos/install-btop.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_btop() {
+  echo "Starting install-btop.sh..."
   sudo apt update
   sudo apt install -y btop
 }

--- a/chromeos/install-chrome.sh
+++ b/chromeos/install-chrome.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_chrome() {
+  echo "Starting install-chrome.sh..."
   sudo mkdir -p /etc/apt/keyrings
   curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg
   sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list'

--- a/chromeos/install-docker.sh
+++ b/chromeos/install-docker.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 install_docker() {
-  echo "Starting Docker installation..."
+  echo "Starting install-docker.sh..."
 
   # Add Docker's official GPG key:
   sudo apt-get update

--- a/chromeos/install-filelight.sh
+++ b/chromeos/install-filelight.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_filelight() {
+  echo "Starting install-filelight.sh..."
   # disk usage analyzer
   sudo apt update
   sudo apt install -y filelight

--- a/chromeos/install-gemini.sh
+++ b/chromeos/install-gemini.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 install_gemini() {
-  echo "Starting Gemini install script..."
+  echo "Starting install-gemini.sh..."
 
   # --- Install Google Gemini CLI ---
 

--- a/chromeos/install-gh-cli.sh
+++ b/chromeos/install-gh-cli.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 echo "Starting install-gh-cli.sh..."
 (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
 	&& sudo mkdir -p -m 755 /etc/apt/keyrings \

--- a/chromeos/install-gh-cli.sh
+++ b/chromeos/install-gh-cli.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "Starting install-gh-cli.sh..."
 (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
 	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
         && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/chromeos/install-node.sh
+++ b/chromeos/install-node.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 install_node() {
-  echo "Starting nvm install script..."
+  echo "Starting install-node.sh..."
 
   # Set NVM_DIR to define the installation directory for nvm.
   # This needs to be set *before* the install script is run.

--- a/chromeos/install-nvidia-sync.sh
+++ b/chromeos/install-nvidia-sync.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 install_nvidia_sync() {
-  echo "Starting NVIDIA Sync installation..."
+  echo "Starting install-nvidia-sync.sh..."
   sudo curl -fsSL https://workbench.download.nvidia.com/stable/linux/gpgkey -o /etc/apt/trusted.gpg.d/ai-workbench-desktop-key.asc
   echo "deb https://workbench.download.nvidia.com/stable/linux/debian default proprietary" | sudo tee -a /etc/apt/sources.list > /dev/null
   sudo apt update

--- a/chromeos/install-opencode.sh
+++ b/chromeos/install-opencode.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 install_opencode() {
-  echo "Starting OpenCode install script..."
+  echo "Starting install-opencode.sh..."
 
   # --- Install OpenCode CLI ---
 

--- a/chromeos/install-tripo.sh
+++ b/chromeos/install-tripo.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_tripo() {
+  echo "Starting install-tripo.sh..."
   sudo apt update
   sudo apt install -y python3-pip python3-venv
 

--- a/chromeos/install-vscode.sh
+++ b/chromeos/install-vscode.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_vscode() {
+  echo "Starting install-vscode.sh..."
   sudo apt-get update
   sudo apt install -y wget gpg
   wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg

--- a/termux/install-antigravity.sh
+++ b/termux/install-antigravity.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_antigravity() {
+  echo "Starting install-antigravity.sh..."
   echo "Antigravity deb repository is incompatible with Termux (requires glibc)."
   return 1
 }

--- a/termux/install-chrome.sh
+++ b/termux/install-chrome.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_chrome() {
+  echo "Starting install-chrome.sh..."
   echo "Google Chrome is not natively supported on Termux without proot/qemu."
   return 1
 }

--- a/termux/install-docker.sh
+++ b/termux/install-docker.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_docker() {
+  echo "Starting install-docker.sh..."
   echo "Docker is not natively supported on Termux without proot/qemu and custom kernels."
   return 1
 }

--- a/termux/install-filelight.sh
+++ b/termux/install-filelight.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_filelight() {
+  echo "Starting install-filelight.sh..."
   echo "Filelight (GUI) is not supported. Use terminal tools like ncdu."
   return 1
 }

--- a/termux/install-gemini.sh
+++ b/termux/install-gemini.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 install_gemini() {
-  echo "Starting Gemini install script..."
+  echo "Starting install-gemini.sh..."
 
   # --- Install Google Gemini CLI ---
 

--- a/termux/install-gh-cli.sh
+++ b/termux/install-gh-cli.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_gh_cli() {
+  echo "Starting install-gh-cli.sh..."
   pkg update
   pkg install -y gh
 }

--- a/termux/install-node.sh
+++ b/termux/install-node.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 install_node() {
-  echo "Starting Node.js install script..."
+  echo "Starting install-node.sh..."
 
   pkg update
   pkg install -y nodejs

--- a/termux/install-ollama.sh
+++ b/termux/install-ollama.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_ollama() {
+  echo "Starting install-ollama.sh..."
   pkg install -y ollama
 }
 

--- a/termux/install-vscode.sh
+++ b/termux/install-vscode.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 install_vscode() {
+  echo "Starting install-vscode.sh..."
   echo "Installing code-server (VS Code for Termux)..."
   pkg update
   pkg install -y tur-repo

--- a/termux/test_install-ollama.sh
+++ b/termux/test_install-ollama.sh
@@ -17,7 +17,7 @@ export PATH="$MOCK_DIR:$PATH"
 OUTPUT="$(install_ollama 2>&1)"
 EXPECTED="Mock pkg called with args: install -y ollama"
 
-if [[ "$OUTPUT" != "$EXPECTED" ]]; then
+if ! echo "$OUTPUT" | grep -q "$EXPECTED"; then
   echo "Test failed: Unexpected output from install_ollama." >&2
   echo "Expected: '$EXPECTED'" >&2
   echo "Actual:   '$OUTPUT'" >&2

--- a/termux/test_install-ollama.sh
+++ b/termux/test_install-ollama.sh
@@ -17,7 +17,7 @@ export PATH="$MOCK_DIR:$PATH"
 OUTPUT="$(install_ollama 2>&1)"
 EXPECTED="Mock pkg called with args: install -y ollama"
 
-if ! echo "$OUTPUT" | grep -q "$EXPECTED"; then
+if [[ "$OUTPUT" != *"$EXPECTED"* ]]; then
   echo "Test failed: Unexpected output from install_ollama." >&2
   echo "Expected: '$EXPECTED'" >&2
   echo "Actual:   '$OUTPUT'" >&2


### PR DESCRIPTION
🎯 What
Added standard `echo "Starting <filename>..."` statements to the beginning of all `chromeos/install-*.sh` and `termux/install-*.sh` scripts to provide clearer progress tracking during the execution of orchestrators like `setup.sh`. Also updated `termux/test_install-ollama.sh` to use `grep -q` rather than strict string matching so that these new echo lines do not break tests.

💡 Why
When `setup.sh` is running, it can take a long time to complete various tasks. The user receives limited feedback about which component is currently being installed. Echoing the filename provides a clear progress indicator.

✅ Verification
Ran the test suite (e.g. `test*.sh` scripts) via `bash`, ensuring that all test mocks still successfully capture execution behavior without failing on the added string output. All tests pass locally.

✨ Result
Setup scripts now emit explicit progress logs that improve operability, while keeping tests green.

---
*PR created automatically by Jules for task [11187894726884677583](https://jules.google.com/task/11187894726884677583) started by @josephrkramer*